### PR TITLE
Fix :webApp:jsRun compilation

### DIFF
--- a/compose-imageviewer/shared/build.gradle.kts
+++ b/compose-imageviewer/shared/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
             dependsOn(jsWasmMain)
             dependencies {
                 implementation("io.ktor:ktor-client-core:$ktorVersion")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-js:1.7.0-RC")
             }
         }
 


### PR DESCRIPTION
This fix allows properly run of JS version of application.
Without this fix ```shared``` module says:
```
> Task :shared:compileKotlinJs
e: Could not find "org.jetbrains.kotlin:kotlinx-atomicfu-runtime" in [/home/user/.local/share/kotlin/daemon]
e: java.lang.IllegalStateException: FATAL ERROR: Could not find "org.jetbrains.kotlin:kotlinx-atomicfu-runtime" in  [/home/user/.local/share/kotlin/daemon]
```