### PR TITLE
Update compose in jetsnack and imageviewer to 1.4.0-dev-wasm09

### DIFF
--- a/compose-imageviewer/gradle.properties
+++ b/compose-imageviewer/gradle.properties
@@ -15,5 +15,5 @@ agp.version=7.1.3
 ktor.version=2.2.1
 kotlin.js.ir.output.granularity=whole-program
 compose.version=1.4.0
-compose.wasm.version=1.4.0-dev-wasm08
+compose.wasm.version=1.4.0-dev-wasm09
 kotlin.version=1.9.0

--- a/compose-imageviewer/kotlin-js-store/yarn.lock
+++ b/compose-imageviewer/kotlin-js-store/yarn.lock
@@ -880,14 +880,6 @@ dom-serialize@^2.2.1:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
-dukat@0.5.8-rc.4:
-  version "0.5.8-rc.4"
-  resolved "https://registry.yarnpkg.com/dukat/-/dukat-0.5.8-rc.4.tgz#90384dcb50b14c26f0e99dae92b2dea44f5fce21"
-  integrity sha512-ZnMt6DGBjlVgK2uQamXfd7uP/AxH7RqI0BL9GLrrJb2gKdDxvJChWy+M9AQEaL+7/6TmxzJxFOsRiInY9oGWTA==
-  dependencies:
-    google-protobuf "3.12.2"
-    typescript "3.9.5"
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -1254,11 +1246,6 @@ glob@^7.1.3, glob@^7.1.7:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
-
-google-protobuf@3.12.2:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.12.2.tgz#50ce9f9b6281235724eb243d6a83e969a2176e53"
-  integrity sha512-4CZhpuRr1d6HjlyrxoXoocoGFnRYgKULgMtikMddA9ztRyYR59Aondv2FioyxWVamRo0rF2XpYawkTCBEQOSkA==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
@@ -2531,11 +2518,6 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-typescript@3.9.5:
-  version "3.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
-  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 typescript@5.0.4:
   version "5.0.4"

--- a/compose-jetsnack/gradle.properties
+++ b/compose-jetsnack/gradle.properties
@@ -3,5 +3,5 @@ kotlin.code.style=official
 android.useAndroidX=true
 agp.version=7.3.0
 compose.version=1.4.0
-compose.wasm.version=1.4.0-dev-wasm08
+compose.wasm.version=1.4.0-dev-wasm09
 kotlin.version=1.9.0


### PR DESCRIPTION
Please note: I have a weird issue in Chrome `Version 114.0.5735.106 (Official Build) (64-bit)`, but no issue in Chrome Beta `Version 115.0.5790.75 (Official Build) beta (64-bit)`:

![Screenshot from 2023-07-10 22-09-15](https://github.com/Kotlin/kotlin-wasm-examples/assets/7372778/fa8bc2d4-6bd0-40ed-a26d-e73cbe30f789)
![Screenshot from 2023-07-10 22-01-07](https://github.com/Kotlin/kotlin-wasm-examples/assets/7372778/5d5ede8c-c997-4fda-b5fe-8084c87a7da1)
