### PR TITLE
Update Node.js version to ensure Windows compatibility

### DIFF
--- a/nodejs-example/build.gradle.kts
+++ b/nodejs-example/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
 }
 
 rootProject.the<NodeJsRootExtension>().apply {
-    nodeVersion = "21.0.0-v8-canary202309143a48826a08"
+    nodeVersion = "21.0.0-v8-canary20230915606fa86055"
     nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
 }
 


### PR DESCRIPTION
The previous version did not have a corresponding Windows file at https://nodejs.org/download/v8-canary/v21.0.0-v8-canary202309143a48826a08/. 
This change ensures that the project can now be built on Windows without altering any existing functionality.

Running this project on Windows before the change results in the following error message:
```
Could not determine the dependencies of task ':kotlinNodeJsSetup'.
> Could not resolve all files for configuration ':detachedConfiguration1'.
   > Could not find org.nodejs:node:21.0.0-v8-canary202309143a48826a08.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/nodejs/node/21.0.0-v8-canary202309143a48826a08/node-21.0.0-v8-canary202309143a48826a08.pom
       - https://nodejs.org/download/v8-canary/v21.0.0-v8-canary202309143a48826a08/node-v21.0.0-v8-canary202309143a48826a08-win-x64.zip Required by: project :

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```