### PR TITLE
Remove compose-jetsnack example

### DIFF
--- a/compose-jetsnack/README.md
+++ b/compose-jetsnack/README.md
@@ -1,6 +1,0 @@
-# Kotlin/Wasm Jetsnack example
-
-> [!IMPORTANT]  
-> The example was moved to the [JetBrains/compose-multiplatform](https://github.com/JetBrains/compose-multiplatform) repository.
->
-> You can find the code of the example here: [compose-multiplatform/examples/jetsnack](https://github.com/JetBrains/compose-multiplatform/blob/master/examples/jetsnack).


### PR DESCRIPTION
This example is removed from the compose-multiplatform repo too

See https://github.com/JetBrains/compose-multiplatform/pull/5511